### PR TITLE
XSRF-TOKEN cookie can be securely set as httpOnly in config

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -136,7 +136,7 @@ class VerifyCsrfToken
         $response->headers->setCookie(
             new Cookie(
                 'XSRF-TOKEN', $request->session()->token(), Carbon::now()->getTimestamp() + 60 * $config['lifetime'],
-                $config['path'], $config['domain'], $config['secure'], false
+                $config['path'], $config['domain'], $config['secure'], $config['http_only']
             )
         );
 


### PR DESCRIPTION
see: https://github.com/laravel/framework/issues/16191